### PR TITLE
Implements GenerateGroups

### DIFF
--- a/src/components/AddGroups.jsx
+++ b/src/components/AddGroups.jsx
@@ -33,8 +33,7 @@ const AddGroups = (props) => {
         <input value={input} onChange={inputChangeHandler} ></input>
       </div>
     )
-  }
-  
+  } 
 }
 
 export default AddGroups;

--- a/src/components/GenerateGroups.jsx
+++ b/src/components/GenerateGroups.jsx
@@ -1,7 +1,43 @@
 import React, { useState } from "react";
 
 const GenerateGroups = (props) => {
+  const { addGroup } = props;
 
+  const [ input, setInput ] = useState(0);
+  const [ modal, setModal ] = useState(false);
+
+  const onClickHandler = () => {
+    if (!modal) {
+      setModal(true);
+    } else if (modal && input === "") {
+      setModal(false);
+    } else {
+      let groups = new Array(Number(input)).fill('');
+      console.log(`Groups pre-map: ${JSON.stringify(groups)}, length: ${groups.length}`)
+      groups = groups.map((val, index) => `Group ${index + 1}`);
+
+      console.log(`Adding groups: ${JSON.stringify(groups)}`);
+
+      addGroup(groups);
+      setModal(false);
+      setInput(0);
+    }
+  }
+
+  const inputChangeHandler = ({ target: { value }}) => setInput(value);
+
+  const checkModal = () => (
+    modal ?
+    <input type="number" value={input} onChange={inputChangeHandler} ></input> 
+    : null
+  )
+
+  return (
+    <div className="generate-groups-container" >
+      <button className="btn-generate-groups" onClick={onClickHandler} >Generate Groups</button>
+      {checkModal()}
+    </div>
+  )
 }
 
 export default GenerateGroups;

--- a/src/components/GenerateGroups.jsx
+++ b/src/components/GenerateGroups.jsx
@@ -1,0 +1,7 @@
+import React, { useState } from "react";
+
+const GenerateGroups = (props) => {
+
+}
+
+export default GenerateGroups;

--- a/src/components/GenerateGroups.jsx
+++ b/src/components/GenerateGroups.jsx
@@ -5,22 +5,26 @@ const GenerateGroups = (props) => {
 
   const [ input, setInput ] = useState(0);
   const [ modal, setModal ] = useState(false);
+  const [ count, setCount ] = useState(1)
 
   const onClickHandler = () => {
     if (!modal) {
       setModal(true);
-    } else if (modal && input === "") {
+    } else if (modal && input === 0) {
       setModal(false);
     } else {
+      let newCount = count;
       let groups = new Array(Number(input)).fill('');
-      console.log(`Groups pre-map: ${JSON.stringify(groups)}, length: ${groups.length}`)
-      groups = groups.map((val, index) => `Group ${index + 1}`);
-
-      console.log(`Adding groups: ${JSON.stringify(groups)}`);
+      groups = groups.map(() => {
+        let str = `Group ${newCount}`
+        newCount++
+        return str;
+      });
 
       addGroup(groups);
       setModal(false);
       setInput(0);
+      setCount(newCount);
     }
   }
 

--- a/src/components/Groups.jsx
+++ b/src/components/Groups.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import GroupsList from "./GroupsList.jsx";
 import AddGroups from "./AddGroups.jsx";
+import GenerateGroups from "./GenerateGroups.jsx";
 
 const Groups = (props) => {
   const { groups, addGroup } = props;
@@ -8,6 +9,7 @@ const Groups = (props) => {
   return (
     <div className="groups-container">
       <AddGroups addGroup={addGroup} />
+      <GenerateGroups addGroup={addGroup} groups={groups} />
       <GroupsList groups={groups} />
     </div>
   )

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -15,11 +15,16 @@ const Main = (props) => {
   const [ currentGroup, setCurrentGroup ] = useState(null);
   const [ pendingGroups, setPendingGroups ] = useState(groups);
 
-  const addGroup = (name) => {
-    let newGroup = new Group(name);
+  const addGroup = (input) => {
+    let toBeAdded;
+    if (typeof input === string) {
+      toBeAdded = new Group(input);
+    } else if (typeof input === array) {
+      toBeAdded = input.map((item) => new Group(item));
+    }
 
-    setPendingGroups([...pendingGroups, newGroup]);
-    setGroups([...groups, newGroup]);
+    setPendingGroups([...pendingGroups, toBeAdded]);
+    setGroups([...groups, toBeAdded]);
   }
 
   const upNextClickHandler = () => {

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -18,15 +18,10 @@ const Main = (props) => {
   const addGroup = (input) => {
     let toBeAdded;
 
-    console.log(`addGroup invoked`)
-    console.log(`Type of input: ${typeof input}`)
-
     if (typeof input === "string") {
       toBeAdded = [new Group(input)];
-      console.log(`String detected in addGroup`)
     } else if (typeof input === "object") {
       toBeAdded = input.map((item) => new Group(item));
-      console.log(`Array detected, toBeAdded: ${JSON.stringify(toBeAdded)}`);
     }
 
     setPendingGroups([...pendingGroups, ...toBeAdded]);

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -11,20 +11,26 @@ const sampleGroups = [
 const Main = (props) => {
   const { session } = props;
 
-  const [ groups, setGroups ] = useState(sampleGroups);
+  const [ groups, setGroups ] = useState([]);
   const [ currentGroup, setCurrentGroup ] = useState(null);
   const [ pendingGroups, setPendingGroups ] = useState(groups);
 
   const addGroup = (input) => {
     let toBeAdded;
-    if (typeof input === string) {
-      toBeAdded = new Group(input);
-    } else if (typeof input === array) {
+
+    console.log(`addGroup invoked`)
+    console.log(`Type of input: ${typeof input}`)
+
+    if (typeof input === "string") {
+      toBeAdded = [new Group(input)];
+      console.log(`String detected in addGroup`)
+    } else if (typeof input === "object") {
       toBeAdded = input.map((item) => new Group(item));
+      console.log(`Array detected, toBeAdded: ${JSON.stringify(toBeAdded)}`);
     }
 
-    setPendingGroups([...pendingGroups, toBeAdded]);
-    setGroups([...groups, toBeAdded]);
+    setPendingGroups([...pendingGroups, ...toBeAdded]);
+    setGroups([...groups, ...toBeAdded]);
   }
 
   const upNextClickHandler = () => {


### PR DESCRIPTION
Adds a GenerateGroups component which allows the user to generate generic groups quickly
Clicking "Generate Groups" opens a modal with an input field which accepts an integer.
Clicking "Generate Groups" will check the input value and generate the appropriate number of groups, using the naming convention "Group <num>".
This process can be repeated and the <num> will track appropriately across multiple invocations.